### PR TITLE
load ss2 as module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,14 @@ jobs:
         run: |
           sudo python3 setup.py install
           python -m pip install --upgrade pip nose2 pyroute2
+          # install fork
+          git clone https://github.com/cherusk/pyroute2.git
+          pushd pyroute2
+          git checkout -B install_ss2_as_module origin/install_ss2_as_module
+          sudo python3 setup.py install
+          popd
+          rmdir --ignore-fail-on-non-empty pyroute2
+
       - name: Test
         run: |
           nose2 --verbose --config ./test/nose2.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,21 @@ ENV EXPORTER_HOME="${EXPORTER_USER_HOME}"
 COPY . /prometheus-ss-exporter
 
 RUN set -ex \
+        && apt-get update \
+        && apt-get install -y git \
+        && apt-get clean \
         && useradd -ms /bin/bash -d ${EXPORTER_HOME} exporter \
         && pip install --no-cache-dir -U pip \
         && cd /prometheus-ss-exporter \
         && python3 setup.py install
+
+# install ss2 from forked pyroute2
+RUN /bin/bash -c "git clone https://github.com/cherusk/pyroute2.git \
+                  && pushd pyroute2 \
+                  && git checkout -B install_ss2_as_module origin/install_ss2_as_module \
+                  && python3 setup.py install \
+                  && popd \
+                  && rmdir --ignore-fail-on-non-empty pyroute2"
 
 EXPOSE 8090
 

--- a/prometheus_ss_exporter/stats.py
+++ b/prometheus_ss_exporter/stats.py
@@ -7,13 +7,13 @@ import logging
 
 
 import importlib.machinery
+import pyroute2.netlink.diag.ss2 as ss2
 
 from . import utils
 
 
 class Gatherer:
     def __init__(self):
-        self._load_logic()
         self._reset_io()
 
         self.args = collections.namedtuple('args', ['tcp',
@@ -29,13 +29,6 @@ class Gatherer:
         self.args.all = False
         self.args.unix = False
 
-    def _load_logic(self):
-        ss2_script_path = utils.which('ss2')
-        self.ss2 = (importlib.
-                    machinery.
-                    SourceFileLoader('ss2',
-                                     ss2_script_path).load_module())
-
     def _reset_io(self):
         if sys.version_info[0] == 2:
             import cStringIO
@@ -47,7 +40,7 @@ class Gatherer:
         _stdout = sys.stdout
         sys.stdout = self.stream_sink
 
-        self.ss2.run(self.args)
+        ss2.run(self.args)
 
         # catch stdout
         sys.stdout = _stdout

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages(),
 
     install_requires=[
-        'pyroute2==0.5.19',
+       # 'pyroute2==0.5.19', installed from fork for now
         'prometheus-client',
         'PyYAML',
         'psutil'


### PR DESCRIPTION
The cli tool is now wrapped into py setuptools logic.

Loading ss2 logic from there harsh.

So let's load it as a module directly.